### PR TITLE
docs(roles): complete "Verificador Externo" page

### DIFF
--- a/content/docs/roles/verifier.md
+++ b/content/docs/roles/verifier.md
@@ -14,3 +14,41 @@ seo:
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---
+## Designación del Verificador Externo
+
+A diferencia de los otros roles del sistema, el Verificador Externo no
+requiere ser designado previamente por la organización que conduce la
+elección. Cualquier persona, independiente del sistema y de la Autoridad
+Electoral, puede asumir este rol descargando el archivo de verificación
+que se publica al cierre de la elección y ejecutando sobre él un programa
+de verificación independiente.
+
+La existencia de este rol es central para la confianza pública en el
+sistema: el resultado de una elección no requiere ser aceptado por el
+solo hecho de haber sido publicado en la plataforma, sino que puede ser
+auditado de forma reproducible por terceros que no participaron de la
+operación del proceso.
+
+## Rol del Verificador Externo
+
+El Verificador Externo descarga el archivo de verificación desde el
+[Portal de
+Información]({{< ref "/docs/functionalities/stats_public_info.md" >}}) de
+la elección y ejecuta sobre él un programa que comprueba todas las
+propiedades criptográficas necesarias, según el procedimiento detallado
+en [Verificación de la
+Elección]({{< ref "/docs/voting-steps/verification.md" >}}). Las
+comprobaciones incluyen las pruebas asociadas a cada voto encriptado, la
+pertenencia de cada voto al padrón, la consistencia del precómputo con
+la información pública, y la correcta combinación de las
+[desencriptaciones
+parciales]({{< ref "/docs/voting-steps/partial_decryptions.md" >}}) hasta
+el resultado final.
+
+UParticipa pone a disposición la implementación de referencia
+[pyrios](https://github.com/clcert/pyrios), un verificador externo
+offline escrito en Go, basado en el verificador del sistema Helios y
+adaptado a Psifos. El uso de esta implementación no es obligatorio:
+cualquier persona u organización puede desarrollar su propio verificador,
+en otro lenguaje y de manera independiente, siempre que respete el
+protocolo descrito en la sección de [Criptografía]({{< ref "/docs/crypto/" >}}).


### PR DESCRIPTION
Closes #12.

Llena el cuerpo de `content/docs/roles/verifier.md`, que hasta ahora sólo contenía el frontmatter de Hugo. La página describe al rol de **Verificador Externo** siguiendo el estilo de `roles/admin.md` y `roles/trustee.md` (dos secciones: *Designación* y *Rol*).

## Contenido propuesto

- **Designación del Verificador Externo** — enfatiza que es el único rol que **no requiere designación previa**: cualquier persona independiente puede asumirlo, y por qué eso es central para la confianza pública en el sistema.
- **Rol del Verificador Externo** — qué hace operacionalmente (descargar el archivo de verificación del Portal de Información, ejecutar el programa) y qué propiedades comprueba (delegando el detalle a `voting-steps/verification.md`). Cierra mencionando `pyrios` como implementación de referencia y aclarando que verificadores alternativos también son válidos siempre que respeten el protocolo de la sección Criptografía.

## Cross-references

- `functionalities/stats_public_info.md` (Portal de Información — escrita)
- `voting-steps/verification.md` (procedimiento — escrita)
- `voting-steps/partial_decryptions.md` (combinación de desencriptaciones — escrita)
- `crypto/` (sección — el `_index.md` existe; las páginas internas son las pendientes en los issues #4 a #8)
- Enlace externo a [`clcert/pyrios`](https://github.com/clcert/pyrios)

## Notas

- Marcado como **Draft** mientras se revisa el contenido y los enlaces.
- Frontmatter intacto (`slug: external-verifier`, `weight`, `toc`).
- Sin figuras en esta primera iteración.