### PR TITLE
docs(software): complete "Interfaz de Usuario" page

### DIFF
--- a/content/docs/software/ui.md
+++ b/content/docs/software/ui.md
@@ -14,3 +14,76 @@ seo:
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---
+La plataforma UParticipa expone varias interfaces de usuario distintas,
+cada una orientada a un rol específico del proceso electoral. A
+continuación se describen las principales, indicando para cada caso qué
+acciones permite y en qué etapa de la elección se utiliza.
+
+## Portal de Información
+
+El Portal de Información es la interfaz **pública** de cada elección.
+Cualquier persona (votante, custodio, miembro de la Junta Electoral o
+público en general) puede consultarlo sin autenticarse. Sus secciones,
+descritas en detalle en [Estadísticas e Información
+Pública]({{< ref "/docs/functionalities/stats_public_info.md" >}}), son:
+
+- **Urna Electrónica**: muestra cada uno de los votos encriptados
+  recibidos por el servidor, sin revelar las preferencias.
+- **Estadísticas**: cantidad de votos recibidos, participación, y
+  distribución de los votos en el tiempo.
+- **Eventos**: registro cronológico de los hitos relevantes de la
+  elección (apertura, modificaciones del padrón, cierre, etc.).
+- **Resultados**: una vez publicados, los conteos por opción.
+- **Verificación**: instrucciones y archivos necesarios para que
+  cualquier persona pueda asumir el rol de [Verificador
+  Externo]({{< ref "/docs/roles/verifier.md" >}}).
+
+## Cabina de Votación
+
+Es la interfaz que utiliza cada [Votante]({{< ref "/docs/roles/voter.md" >}})
+durante la jornada electoral. Solamente se accede a ella después de la
+[Autentificación
+Externa]({{< ref "/docs/functionalities/auth.md" >}}) y de la
+verificación de habilitación en el padrón. La cabina guía al votante a
+través de los cinco pasos descritos en [Envío de
+Votos]({{< ref "/docs/voting-steps/vote_casting.md" >}}): selección de
+preferencias, encriptación del voto en el navegador, revisión, envío
+final y descarga del Certificado de Votación.
+
+## Portal del Custodio de Clave
+
+Esta interfaz está reservada a las personas designadas como [Custodios
+de Clave]({{< ref "/docs/roles/trustee.md" >}}). Permite las dos
+operaciones críticas que cada Custodio debe realizar:
+
+- Participar en la [Ceremonia de Creación de
+  Claves]({{< ref "/docs/voting-steps/key_generation.md" >}}) antes del
+  inicio de la elección, generando su clave privada y sincronizándose
+  con los demás Custodios.
+- Una vez cerrada la elección y realizado el precómputo, enviar su
+  [desencriptación
+  parcial]({{< ref "/docs/voting-steps/partial_decryptions.md" >}}) para
+  contribuir al cómputo del resultado final.
+
+## Panel del Administrador
+
+Es la interfaz que utiliza el [Administrador]({{< ref "/docs/roles/admin.md" >}})
+para configurar y operar la elección. Concentra las tareas de la fase
+previa (carga del padrón, definición de preguntas y candidaturas,
+registro de Custodios), de la jornada (apertura, monitoreo, eventuales
+modificaciones del padrón) y del cierre (cierre de la elección, gatillo
+del precómputo, publicación de resultados, eliminación posterior de la
+elección). Todas las acciones del Administrador quedan registradas en
+la sección **Eventos** del Portal de Información.
+
+## Aplicación móvil para Custodios
+
+Adicionalmente a las interfaces web, se encuentra en desarrollo una
+aplicación móvil destinada a los Custodios de Clave. Su objetivo es
+reemplazar el flujo de escritorio actual de la Ceremonia de Creación de
+Claves y del envío de desencriptaciones parciales por un flujo móvil
+nativo, simplificando la operación y reduciendo el equipamiento
+requerido por cada Custodio. El [Código
+Fuente]({{< ref "/docs/software/source_code.md" >}}) de esta aplicación
+se publica en los repositorios `psifos_mobile_app` y
+`psifos_mobile_crypto`.


### PR DESCRIPTION
Closes #11.

Llena el cuerpo de `content/docs/software/ui.md`, que hasta ahora sólo contenía el frontmatter de Hugo. La página describe las cinco interfaces de usuario que expone la plataforma, cada una asociada a un rol específico, delegando los detalles operacionales a las páginas ya escritas.

## Estructura propuesta

- **Portal de Información** (público) — resumen de sus 5 secciones, delegando a `functionalities/stats_public_info.md`.
- **Cabina de Votación** (votante) — delegando a `voting-steps/vote_casting.md`.
- **Portal del Custodio de Clave** (custodio) — los dos flujos clave (ceremonia + desencriptación parcial), delegando a `voting-steps/key_generation.md` y `voting-steps/partial_decryptions.md`.
- **Panel del Administrador** (admin) — tareas a lo largo del ciclo electoral, delegando a `roles/admin.md`.
- **Aplicación móvil para Custodios** (en desarrollo) — menciona los repositorios `psifos_mobile_app` y `psifos_mobile_crypto`, vía `software/source_code.md`.

## Notas

- **Sin screenshots.** En el repositorio no hay capturas de pantalla committeadas (sólo existe `assets/images/voting_steps/key_generation.png`). Agregar `{{< figure >}}` con archivos inexistentes rompería el build, así que esta primera iteración es **sólo prosa**. Las capturas pueden incorporarse en un follow-up.
- **Consideraciones de diseño** (mobile-first, accesibilidad, idioma, framework) mencionadas en el issue original no se incluyen aquí porque no tengo información de primera mano sobre las decisiones tomadas en el booth/admin. Son material para un follow-up con input del equipo.
- Frontmatter intacto (`slug: user-interface`, `weight: 502`).
- Marcado como **Draft** mientras se revisa contenido y enlaces.
- Las 10 referencias `{{< ref ... >}}` apuntan a archivos existentes, así que Hugo no rompe el build (incluso para las páginas que aún están vacías como `roles/verifier.md` o `roles/voter.md`, ya cubiertas en los PRs #14 y #16 respectivamente).